### PR TITLE
Resolve executable paths via YAML override, env, site default, autode…

### DIFF
--- a/src/lume_ace3p/__init__.py
+++ b/src/lume_ace3p/__init__.py
@@ -1,64 +1,8 @@
-import os, glob, shutil, warnings
-
-if 'NERSC_HOST' in os.environ:
-    PLATFORM = os.environ['NERSC_HOST']
-elif 'HOSTNAME' in os.environ:
-    PLATFORM = os.environ['HOSTNAME']
-else:
-    PLATFORM = os.uname()[1]
-
-try:
-    if PLATFORM.startswith('sdf'):
-        os.environ['ACE3P_PATH'] = '/sdf/group/rfar/ace3p/bin/'
-        os.environ['CUBIT_PATH'] = '/sdf/group/rfar/software/'
-        os.environ['MPI_CALLER'] = 'srun'
-    elif PLATFORM.startswith('perlmutter'):
-        os.environ['ACE3P_PATH'] = '/global/cfs/cdirs/ace3p/perlmutter/CPU/'
-        os.environ['CUBIT_PATH'] = '/global/cfs/cdirs/ace3p/perlmutter/CPU/'
-        os.environ['MPI_CALLER'] = 'srun'
-    else:
-        ace3p_dir = shutil.which('omega3p')
-        if ace3p_dir is not None:
-            ace3p_dir = ace3p_dir.strip('omega3p')
-            os.environ['ACE3P_PATH'] = ace3p_dir
-        else:
-            ace3p_dir = glob.glob('**/ace3p/bin', root_dir=os.path.expanduser('~'), recursive=True)
-            if not ace3p_dir:
-                raise RuntimeError('The ace3p installation was not found. Set ACE3P_PATH manually.')
-            os.environ['ACE3P_PATH'] = ace3p_dir[0]
-
-        cubit_dir = shutil.which('cubit')
-        if cubit_dir is not None:
-            cubit_dir = cubit_dir.strip('cubit')
-            os.environ['CUBIT_PATH'] = cubit_dir
-        else:
-            cubit_dir = glob.glob('**/Cubit*', root_dir=os.path.expanduser('~'), recursive=True)
-            if not cubit_dir:
-                raise RuntimeError('The cubit installation was not found. Set CUBIT_PATH manually.')
-            os.environ['CUBIT_PATH'] = cubit_dir[0]
-
-        mpi_caller = shutil.which('mpirun')
-        if mpi_caller is None:
-            raise RuntimeError('MPI installation not found. Set MPI_CALLER manually.')
-        os.environ['MPI_CALLER'] = mpi_caller
-
-except RuntimeError as e:
-    warnings.warn(
-        f"ACE3P environment not fully configured: {e} "
-        "Workflows will fail at runtime until the environment is set up correctly."
-    )
-    for var in ('ACE3P_PATH', 'CUBIT_PATH', 'MPI_CALLER'):
-        os.environ.setdefault(var, '')
-
-# Geant4 env vars are set by the user's external setup script; ensure they exist
-# so module imports do not fail when running unrelated workflows.
-for var in ('GEANT4_APP_PATH', 'GEANT4_APP_EXE'):
-    os.environ.setdefault(var, '')
-
 from .workflow import Omega3PWorkflow, S3PWorkflow, Geant4Workflow
 from .cubit import Cubit
 from .ace3p import Omega3P, S3P
 from .acdtool import Acdtool
 from .geant4 import Geant4
 from .particles import Particles
+from .paths import resolve_paths
 from .tools import WriteOmega3PDataTable, WriteS3PDataTable, WriteXoptData

--- a/src/lume_ace3p/acdtool.py
+++ b/src/lume_ace3p/acdtool.py
@@ -4,12 +4,11 @@ import subprocess
 from lume.base import CommandWrapper
 
 class Acdtool(CommandWrapper):
-    
-    MPI_CALLER = os.environ['MPI_CALLER']
-    ACE3P_PATH = os.environ['ACE3P_PATH']
-    
-    def __init__(self, *args, **kwargs):
+
+    def __init__(self, *args, ace3p_path=None, mpi_caller=None, **kwargs):
         super().__init__(*args, **kwargs)
+        self.ACE3P_PATH = ace3p_path if ace3p_path is not None else os.environ.get('ACE3P_PATH', '')
+        self.MPI_CALLER = mpi_caller if mpi_caller is not None else os.environ.get('MPI_CALLER', '')
         if self.workdir is None:
             self.workdir = os.getcwd()
         if not os.path.exists(self.workdir):

--- a/src/lume_ace3p/ace3p.py
+++ b/src/lume_ace3p/ace3p.py
@@ -7,12 +7,13 @@ from lume.base import CommandWrapper
 
 class ACE3P(CommandWrapper):
 
-    MPI_CALLER = os.environ['MPI_CALLER']
-    ACE3P_PATH = os.environ['ACE3P_PATH']
     module_name = ''
 
-    def __init__(self, *args, ace3p_tasks=1, ace3p_cores=1, ace3p_opts='', **kwargs):
+    def __init__(self, *args, ace3p_tasks=1, ace3p_cores=1, ace3p_opts='',
+                 ace3p_path=None, mpi_caller=None, **kwargs):
         super().__init__(*args, **kwargs)
+        self.ACE3P_PATH = ace3p_path if ace3p_path is not None else os.environ.get('ACE3P_PATH', '')
+        self.MPI_CALLER = mpi_caller if mpi_caller is not None else os.environ.get('MPI_CALLER', '')
         self.ace3p_tasks = ace3p_tasks
         self.ace3p_cores = ace3p_cores
         self.ace3p_opts = ace3p_opts

--- a/src/lume_ace3p/cubit.py
+++ b/src/lume_ace3p/cubit.py
@@ -5,12 +5,11 @@ from lume.base import CommandWrapper
 
 class Cubit(CommandWrapper):
 
-    MPI_CALLER = os.environ['MPI_CALLER']
-    ACE3P_PATH = os.environ['ACE3P_PATH']
-    CUBIT_PATH = os.environ['CUBIT_PATH']
-    
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, ace3p_path=None, cubit_path=None, mpi_caller=None, **kwargs):
         super().__init__(*args, **kwargs)
+        self.ACE3P_PATH = ace3p_path if ace3p_path is not None else os.environ.get('ACE3P_PATH', '')
+        self.CUBIT_PATH = cubit_path if cubit_path is not None else os.environ.get('CUBIT_PATH', '')
+        self.MPI_CALLER = mpi_caller if mpi_caller is not None else os.environ.get('MPI_CALLER', '')
         if self.workdir is None:
             self.workdir = os.getcwd()
         if not os.path.exists(self.workdir):

--- a/src/lume_ace3p/geant4.py
+++ b/src/lume_ace3p/geant4.py
@@ -6,12 +6,13 @@ from lume.base import CommandWrapper
 
 class Geant4(CommandWrapper):
 
-    MPI_CALLER = os.environ.get('MPI_CALLER', '')
-    GEANT4_APP_PATH = os.environ.get('GEANT4_APP_PATH', '')
-    GEANT4_APP_EXE  = os.environ.get('GEANT4_APP_EXE', '')
-
-    def __init__(self, *args, geant4_threads=1, geant4_opts='', **kwargs):
+    def __init__(self, *args, geant4_threads=1, geant4_opts='',
+                 mpi_caller=None, geant4_app_path=None, geant4_app_exe=None,
+                 **kwargs):
         super().__init__(*args, **kwargs)
+        self.MPI_CALLER = mpi_caller if mpi_caller is not None else os.environ.get('MPI_CALLER', '')
+        self.GEANT4_APP_PATH = geant4_app_path if geant4_app_path is not None else os.environ.get('GEANT4_APP_PATH', '')
+        self.GEANT4_APP_EXE = geant4_app_exe if geant4_app_exe is not None else os.environ.get('GEANT4_APP_EXE', '')
         self.geant4_threads = geant4_threads
         self.geant4_opts = geant4_opts if geant4_opts is not None else ''
         if self.workdir is None:

--- a/src/lume_ace3p/paths.py
+++ b/src/lume_ace3p/paths.py
@@ -1,0 +1,57 @@
+import os, glob, shutil
+
+from .site_defaults import SITE_DEFAULTS, detect_site
+
+_MISSING = ''
+
+def _autodetect_ace3p():
+    found = shutil.which('omega3p')
+    if found:
+        return os.path.dirname(found) + os.sep
+    matches = glob.glob('**/ace3p/bin', root_dir=os.path.expanduser('~'), recursive=True)
+    if matches:
+        return os.path.join(os.path.expanduser('~'), matches[0]) + os.sep
+    return _MISSING
+
+def _autodetect_cubit():
+    found = shutil.which('cubit')
+    if found:
+        return os.path.dirname(found) + os.sep
+    matches = glob.glob('**/Cubit*', root_dir=os.path.expanduser('~'), recursive=True)
+    if matches:
+        return os.path.join(os.path.expanduser('~'), matches[0]) + os.sep
+    return _MISSING
+
+def _autodetect_mpi():
+    return shutil.which('mpirun') or _MISSING
+
+def _autodetect_none():
+    return _MISSING
+
+_RESOLVERS = {
+    'ace3p':           ('ACE3P_PATH',      _autodetect_ace3p),
+    'cubit':           ('CUBIT_PATH',      _autodetect_cubit),
+    'mpi':             ('MPI_CALLER',      _autodetect_mpi),
+    'geant4_app_path': ('GEANT4_APP_PATH', _autodetect_none),
+    'geant4_app_exe':  ('GEANT4_APP_EXE',  _autodetect_none),
+}
+
+def resolve_paths(yaml_overrides=None):
+    """Resolve tool paths.
+
+    Precedence (highest first): YAML override > environment variable
+    > site default (matched by hostname) > autodetect on PATH/$HOME.
+
+    Returns a dict with keys: ace3p, cubit, mpi, geant4_app_path,
+    geant4_app_exe. Missing entries are returned as empty strings so
+    callers can do truthiness checks (used by dry_run auto-enable).
+    """
+    overrides = yaml_overrides or {}
+    site_paths = SITE_DEFAULTS.get(detect_site(), {})
+    resolved = {}
+    for key, (env_var, autodetect) in _RESOLVERS.items():
+        resolved[key] = (overrides.get(key)
+                         or os.environ.get(env_var)
+                         or site_paths.get(key)
+                         or autodetect())
+    return resolved

--- a/src/lume_ace3p/site_defaults.py
+++ b/src/lume_ace3p/site_defaults.py
@@ -1,0 +1,23 @@
+import os
+
+SITE_DEFAULTS = {
+    'sdf': {
+        'ace3p': '/sdf/group/rfar/ace3p/bin/',
+        'cubit': '/sdf/group/rfar/software/',
+        'mpi':   'srun',
+    },
+    'perlmutter': {
+        'ace3p': '/global/cfs/cdirs/ace3p/perlmutter/CPU/',
+        'cubit': '/global/cfs/cdirs/ace3p/perlmutter/CPU/',
+        'mpi':   'srun',
+    },
+}
+
+def detect_site():
+    host = (os.environ.get('NERSC_HOST')
+            or os.environ.get('HOSTNAME')
+            or os.uname()[1])
+    for prefix in SITE_DEFAULTS:
+        if host.startswith(prefix):
+            return prefix
+    return None

--- a/src/lume_ace3p/workflow.py
+++ b/src/lume_ace3p/workflow.py
@@ -7,9 +7,12 @@ from lume_ace3p.ace3p import Omega3P, S3P
 from lume_ace3p.acdtool import Acdtool
 from lume_ace3p.geant4 import Geant4
 from lume_ace3p.particles import Particles
+from lume_ace3p.paths import resolve_paths
 from lume_ace3p.tools import WriteOmega3PDataTable, WriteS3PDataTable
 
 class ACE3PWorkflow:
+
+    _requires_ace3p = True
 
     def __init__(self, workflow_dict, input_dict=None, output_dict=None):
         self.input_dict = input_dict
@@ -28,9 +31,13 @@ class ACE3PWorkflow:
         self.skip_solver = workflow_dict.get('skip_solver', False)
         self.skip_acdtool = workflow_dict.get('skip_acdtool', False)
         self.skip_meshconvert = workflow_dict.get('skip_meshconvert', False)
-        # Dry run: explicit flag or auto-detect when ACE3P tools aren't available
+        # Resolve executable paths: YAML > env > site default > autodetect
+        self.paths = resolve_paths(workflow_dict.get('paths'))
+        # Dry run: explicit flag or auto-detect when ACE3P tools aren't available.
+        # Subclasses that don't depend on ACE3P (e.g. Geant4Workflow) override
+        # _requires_ace3p and re-evaluate dry_run with their own criteria.
         self.dry_run = workflow_dict.get('dry_run', False)
-        if not self.dry_run and not os.environ.get('ACE3P_PATH', ''):
+        if self._requires_ace3p and not self.dry_run and not self.paths['ace3p']:
             self.dry_run = True
             print('ACE3P environment not configured, enabling dry run mode.')
 
@@ -129,7 +136,10 @@ class Omega3PWorkflow(ACE3PWorkflow):
 
         #Load Cubit journal, update values, and run
         if self.cubit_input is not None and not skip_cubit:
-            self.cubit_obj = Cubit(self.cubit_input, workdir=self.workdir)
+            self.cubit_obj = Cubit(self.cubit_input, workdir=self.workdir,
+                                   ace3p_path=self.paths['ace3p'],
+                                   cubit_path=self.paths['cubit'],
+                                   mpi_caller=self.paths['mpi'])
             if input_dict is not None:
                 self.cubit_obj.set_value(input_dict)
             self.cubit_obj.run(mcflag=not skip_meshconvert)
@@ -144,7 +154,9 @@ class Omega3PWorkflow(ACE3PWorkflow):
                                   ace3p_tasks=self.ace3p_tasks,
                                   ace3p_cores=self.ace3p_cores,
                                   ace3p_opts=self.ace3p_opts,
-                                  workdir=self.workdir)
+                                  workdir=self.workdir,
+                                  ace3p_path=self.paths['ace3p'],
+                                  mpi_caller=self.paths['mpi'])
             if input_dict is not None:
                 self.omega3p_obj.set_value(input_dict)
             self.omega3p_obj.run()
@@ -153,7 +165,9 @@ class Omega3PWorkflow(ACE3PWorkflow):
 
         #Load acdtool rfpost input and run
         if self.rfpost_input is not None and not skip_acdtool:
-            self.acdtool_obj = Acdtool(self.rfpost_input, workdir=self.workdir)
+            self.acdtool_obj = Acdtool(self.rfpost_input, workdir=self.workdir,
+                                       ace3p_path=self.paths['ace3p'],
+                                       mpi_caller=self.paths['mpi'])
             self.acdtool_obj.run()
         elif skip_acdtool:
             print('Acdtool postprocess step skipped.')
@@ -263,7 +277,10 @@ class S3PWorkflow(ACE3PWorkflow):
 
         #Load Cubit journal, update values, and run
         if self.cubit_input is not None and not skip_cubit:
-            self.cubit_obj = Cubit(self.cubit_input, workdir=self.workdir)
+            self.cubit_obj = Cubit(self.cubit_input, workdir=self.workdir,
+                                   ace3p_path=self.paths['ace3p'],
+                                   cubit_path=self.paths['cubit'],
+                                   mpi_caller=self.paths['mpi'])
             if input_dict is not None:
                 self.cubit_obj.set_value(input_dict)
             self.cubit_obj.run(mcflag=not skip_meshconvert)
@@ -278,7 +295,9 @@ class S3PWorkflow(ACE3PWorkflow):
                                ace3p_tasks=self.ace3p_tasks,
                                ace3p_cores=self.ace3p_cores,
                                ace3p_opts=self.ace3p_opts,
-                               workdir=self.workdir)
+                               workdir=self.workdir,
+                               ace3p_path=self.paths['ace3p'],
+                               mpi_caller=self.paths['mpi'])
             if input_dict is not None:
                 self.s3p_obj.set_value(input_dict)
             self.s3p_obj.run()
@@ -351,6 +370,8 @@ class S3PWorkflow(ACE3PWorkflow):
 
 class Geant4Workflow(ACE3PWorkflow):
 
+    _requires_ace3p = False
+
     def __init__(self, workflow_dict, input_dict=None, output_dict=None,
                  particle_params=None):
         super().__init__(workflow_dict, input_dict, output_dict)
@@ -367,8 +388,7 @@ class Geant4Workflow(ACE3PWorkflow):
         # Re-evaluate dry_run for Geant4: ACE3P_PATH is irrelevant here.
         # Honor an explicit YAML setting; otherwise auto-enable only if Geant4 env is unset.
         if 'dry_run' not in workflow_dict:
-            self.dry_run = (not os.environ.get('GEANT4_APP_PATH', '')
-                            or not os.environ.get('GEANT4_APP_EXE', ''))
+            self.dry_run = not (self.paths['geant4_app_path'] and self.paths['geant4_app_exe'])
             if self.dry_run:
                 print('Geant4 environment not configured, enabling dry run mode.')
 
@@ -440,7 +460,10 @@ class Geant4Workflow(ACE3PWorkflow):
                 self.geant4_obj = Geant4(self.geant4_input,
                                          geant4_threads=self.geant4_threads,
                                          geant4_opts=self.geant4_opts,
-                                         workdir=self.workdir)
+                                         workdir=self.workdir,
+                                         mpi_caller=self.paths['mpi'],
+                                         geant4_app_path=self.paths['geant4_app_path'],
+                                         geant4_app_exe=self.paths['geant4_app_exe'])
                 self.geant4_obj.set_value({'/run/numberOfThreads': self.geant4_threads})
                 if particle_file_path is not None:
                     self.geant4_obj.set_particle_file(particle_file_path,
@@ -455,7 +478,10 @@ class Geant4Workflow(ACE3PWorkflow):
         self.geant4_obj = Geant4(self.geant4_input,
                                  geant4_threads=self.geant4_threads,
                                  geant4_opts=self.geant4_opts,
-                                 workdir=self.workdir)
+                                 workdir=self.workdir,
+                                 mpi_caller=self.paths['mpi'],
+                                 geant4_app_path=self.paths['geant4_app_path'],
+                                 geant4_app_exe=self.paths['geant4_app_exe'])
         self.geant4_obj.set_value({'/run/numberOfThreads': self.geant4_threads})
         if particle_file_path is not None:
             self.geant4_obj.set_particle_file(os.path.basename(particle_file_path),


### PR DESCRIPTION
…tect

Previously, paths to ACE3P/Cubit/MPI/Geant4 binaries were read into class-level attributes at import time, with site-specific paths and a glob-based autodetect baked into __init__.py. This made YAML-level overrides impossible after import and emitted a runtime warning even for users running only the Geant4 workflow.

Introduce a paths.resolve_paths() helper with explicit precedence (YAML > env var > site default > autodetect) called once per workflow construction. Tool classes now accept *_path kwargs, falling back to env vars when not provided. Site defaults move to a new site_defaults.py data table. Geant4Workflow opts out of the ACE3P dry-run check via a _requires_ace3p flag.

Generated with AI

Co-Authored-By: SLAC AI