### PR TITLE
Update documentation for Geant4, Particles, path resolution, and modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ by Ryan Roussel for optimization.
 
 The user submits a batch script to HPC nodes which calls `run_lume_ace3p.py`
 with a user-defined YAML configuration. The entry point automatically calls
-Cubit, the requested ACE3P module (Omega3P, S3P, …), and acdtool, parses the
-output, and writes results to a tab-delimited file or hands them to Xopt for
-optimization.
+Cubit, the requested ACE3P module (Omega3P, S3P, T3P, or Track3P), and
+acdtool, parses the output, and writes results to a tab-delimited file or
+hands them to Xopt for optimization. A separate Geant4 module is also
+supported for downstream dose calculations driven by Track3P particle output.
 
 ## Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,9 +19,10 @@ for optimization.
 A user submits a batch script to HPC nodes which calls `run_lume_ace3p.py` with a
 user-defined YAML input file. That input file defines dictionaries for workflow
 settings, input parameters, and output parameters. From there, the entry point
-automatically calls Cubit, the requested ACE3P module (Omega3P, S3P, …), and
-acdtool, parses the output, and writes results to a tab-delimited file or hands
-them to Xopt for optimization.
+automatically calls Cubit, the requested ACE3P module (Omega3P, S3P, T3P, or
+Track3P), and acdtool, parses the output, and writes results to a tab-delimited
+file or hands them to Xopt for optimization. A separate Geant4 module is also
+supported for downstream dose calculations driven by Track3P particle output.
 
 To run a parameter sweep or optimization the user typically provides:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,7 +1,8 @@
 # Installation and setup
 
-`lume-ace3p` is a Python package that depends on `lume-base>=0.3.3` and
-`xopt>=2.2.2`. On NERSC Perlmutter and SLAC S3DF, pre-made conda environments
+`lume-ace3p` is a Python package that requires Python 3.9 or newer and
+depends on `lume-base>=0.3.3`, `xopt>=2.2.2`, `ruamel.yaml`, `numpy`, and
+`pandas`. On NERSC Perlmutter and SLAC S3DF, pre-made conda environments
 already contain `lume-ace3p` and its dependencies, and no installation step
 is needed — just activate the environment. On any other system, install with
 pip from a clone of the repository.
@@ -28,8 +29,9 @@ package can be imported as `lume_ace3p`.
 
 :::{note}
 ACE3P itself is *not* installed by pip. To run real workflows you need an
-ACE3P installation reachable through the `ACE3P_PATH` environment variable
-(see [](#dry-run-mode) below for testing without ACE3P).
+ACE3P installation reachable through one of the resolution mechanisms
+described in [](#executable-paths) below (or see [](#dry-run-mode) for
+testing without ACE3P).
 :::
 
 ## Perlmutter (NERSC)
@@ -97,6 +99,49 @@ To run the examples from an S3DF iana terminal:
 4. Submit a batch job from one of the *S3DF* examples with `sbatch`.
 5. View results in the folder the job was run from.
 
+(executable-paths)=
+## Executable paths
+
+`lume-ace3p` needs to know where to find ACE3P, Cubit, the MPI launcher,
+and (for Geant4 workflows) the Geant4 application. Each path is resolved
+independently, in the following order of precedence (highest first):
+
+1. **YAML override** — a `paths` mapping in `workflow_parameters`, e.g.
+
+   ```yaml
+   workflow_parameters :
+     'paths' :
+       'ace3p' : '/path/to/ace3p/bin/'
+       'cubit' : '/path/to/cubit/'
+       'mpi'   : 'srun'
+       'geant4_app_path' : '/path/to/geant4-app/'
+       'geant4_app_exe'  : 'my_geant4_app'
+   ```
+
+2. **Environment variable** — one per tool:
+
+   | Path key          | Environment variable |
+   |-------------------|----------------------|
+   | `ace3p`           | `ACE3P_PATH`         |
+   | `cubit`           | `CUBIT_PATH`         |
+   | `mpi`             | `MPI_CALLER`         |
+   | `geant4_app_path` | `GEANT4_APP_PATH`    |
+   | `geant4_app_exe`  | `GEANT4_APP_EXE`     |
+
+3. **Site default** — when running on a recognized site (Perlmutter or
+   S3DF), built-in defaults are used. Site detection compares the
+   hostname (via `NERSC_HOST`, `HOSTNAME`, or `os.uname()`) against the
+   prefixes `'perlmutter'` and `'sdf'`.
+
+4. **Autodetect** — for `ace3p` and `cubit`, `lume-ace3p` looks for the
+   relevant binary on `PATH` (e.g. `omega3p`, `cubit`) and falls back to
+   a recursive glob under `$HOME` (`**/ace3p/bin`, `**/Cubit*`). For
+   `mpi`, it falls back to `mpirun` on `PATH`. The Geant4 keys are not
+   autodetected — they must be set explicitly when needed.
+
+If a path cannot be resolved, the corresponding tool is unavailable and
+the workflow auto-enables dry-run mode (see below).
+
 (dry-run-mode)=
 ## Dry-run mode
 
@@ -111,12 +156,21 @@ or acdtool. This is useful for:
 
 There are two ways to enable it:
 
-1. **Automatic.** If the `ACE3P_PATH` environment variable is unset when the
-   workflow runs, dry-run mode is enabled automatically and `lume-ace3p`
-   prints:
+1. **Automatic.** If the `ace3p` path cannot be resolved (no YAML
+   override, no `ACE3P_PATH`, no site default, and no autodetected
+   binary), dry-run mode is enabled automatically for ACE3P workflows
+   and `lume-ace3p` prints:
 
    ```
    ACE3P environment not configured, enabling dry run mode.
+   ```
+
+   For Geant4 workflows, the analogous trigger is that *both*
+   `geant4_app_path` and `geant4_app_exe` are unresolved, in which case
+   `lume-ace3p` prints:
+
+   ```
+   Geant4 environment not configured, enabling dry run mode.
    ```
 
 2. **Explicit.** Add `dry_run: True` to `workflow_parameters` in the YAML

--- a/docs/parameter_sweep.md
+++ b/docs/parameter_sweep.md
@@ -10,8 +10,11 @@ To set up a parameter sweep, two to four dictionaries must be provided in the
 
 - `workflow_parameters` — filenames, HPC settings, and other configuration
   used for the parameter sweep.
-- `cubit_input_parameters` — input names and corresponding vector values to
-  sweep through, for parameters pertaining to the geometry.
+- `cubit_input_parameters` (or, equivalently, `input_parameters`) — input
+  names and corresponding vector values to sweep through, for parameters
+  pertaining to the geometry. The two keys are aliases; the Omega3P
+  example below uses `cubit_input_parameters` for clarity, while the S3P
+  example uses `input_parameters`.
 - `ace3p_input_parameters` — input names and corresponding vector values to
   sweep through, for parameters pertaining to ACE3P settings.
 - `output_parameters` — output quantities to store in an output array for
@@ -219,3 +222,118 @@ interactive plot. To use it, run `s3p_sweep_plot.py` and load the appropriate
 S3P `sweep_output_file` from the file prompt. Try `s3p_demo_sweep_output.txt`
 in the `plotting` folder for an interactive demo. See [](plotting.md) for
 details.
+
+## Gaussian-process (low-fidelity) parameter sweep
+
+For S3P, `lume-ace3p` also supports a low-fidelity sweep mode that fits a
+Gaussian Process to the simulator output and then samples the GP on a
+tensor grid — useful for cheaply exploring parameter space without
+running every grid point through S3P. The mode is selected with
+`mode: 'gp_parameter_sweep'` and `module: 's3p'`.
+
+Three sections must be supplied in addition to `workflow_parameters`:
+
+- `sweep_parameters` — the tensor grid the trained GP is evaluated on.
+- `vocs_parameters` — Xopt VOCS for the exploration phase. The
+  `objectives` block uses `'explore'` as the optimization keyword.
+- `xopt_parameters` — Xopt driver settings. `num_step` controls the
+  number of GP-guided exploration steps; `num_random` (default 5)
+  controls the random-seeding phase; `improvement_threshold` (default
+  0.01) and `patience` (default 5) configure early stopping.
+
+A complete example is shipped as
+[examples/lf_param_sweep.yaml](https://github.com/slaclab/lume-ace3p/blob/main/examples/lf_param_sweep.yaml):
+
+```yaml
+workflow_parameters :
+    'mode' : 'GP_parameter_sweep'
+    'module' : 's3p'
+    'cubit_input': 'bend-90degree_mf.jou'
+    'ace3p_input': 'bend-90degree_mf.s3p'
+    'ace3p_tasks': 16
+    'ace3p_cores': 4
+
+sweep_parameters :
+    'cornercut' :
+        min : 12.5
+        max : 13.5
+        num : 10
+    'wgwidth' :
+        min : 21
+        max : 22
+        num : 10
+
+vocs_parameters :
+    'variables' :
+        'cornercut': [12.5, 13.5]
+        'wgwidth':   [21, 22]
+    'objectives' :
+        'S(1,1)_12.0e+09': 'explore'
+
+xopt_parameters :
+    num_step : 3
+```
+
+The GP-sampled grid is written to `sweep_output.txt`; the actual S3P
+evaluations performed during exploration are written to
+`sim_output.txt` and `sim_output_all_values.txt`.
+
+## Track3P particle weighting
+
+The `mode: 'particle_weight'` workflow is a standalone post-processing
+step that reads a Track3P particle dump, filters by impact order /
+face id, bins by axial position, and writes a weighted-particle file
+suitable as a Geant4 source. No ACE3P invocation occurs.
+
+```yaml
+workflow_parameters :
+  'mode' : 'particle_weight'
+  'module' : 'track3p'
+  'particle_input' : 'sample_track3p_particles.txt'
+  'particle_output' : 'track3p_particles_weighted.txt'
+
+particle_parameters :
+  'impact_order'   : 1
+  'impact_face_id' : 4
+  'work_function'  : 4.5
+  'dt'             : 1.0e-10
+  'num_bins'       : 8
+  'beta'           : [50, 55, 60, 65, 65, 60, 55, 50]
+```
+
+See [](yaml_reference.md#particle_parameters) for the full key list.
+
+## Geant4 dose-calculation workflow
+
+The `mode: 'geant4'` workflow drives a Geant4 application using a macro
+file, optional geometry files, and a particle-source file. The source
+file can either be supplied directly via `geant4_particle_file` or
+generated on the fly from a Track3P dump by also providing a
+`particle_parameters` section (chaining the same logic as
+`mode: 'particle_weight'`).
+
+A minimal YAML skeleton:
+
+```yaml
+workflow_parameters :
+  'mode' : 'geant4'
+  'module' : 'geant4'
+  'geant4_input'          : 'dose.mac'
+  'geant4_geometry_files' : ['cavity.gdml']
+  'geant4_particle_file'  : 'track3p_particles_weighted.txt'
+  'geant4_scoring_output' : 'dose_scoring.txt'
+  'geant4_threads'        : 4
+
+geant4_input_parameters :
+  '/gun/energy' : 1.0
+  # additional macro overrides…
+
+output_parameters :
+  'total_dose' : ['scoring', 'total']
+  'peak_dose'  : ['scoring', 'peak']
+```
+
+Geant4 paths are resolved through the same precedence chain as ACE3P —
+see [](installation.md#executable-paths). If `GEANT4_APP_PATH` /
+`GEANT4_APP_EXE` (or YAML / site-default equivalents) are unset,
+dry-run mode is auto-enabled.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,44 @@
 
 ## FAQs
 
+### Why did `lume-ace3p` enable dry-run mode by itself?
+
+When you see one of these messages on startup —
+
+```
+ACE3P environment not configured, enabling dry run mode.
+```
+```
+Geant4 environment not configured, enabling dry run mode.
+```
+
+— `lume-ace3p` could not resolve the path to ACE3P (or to the Geant4
+application, for `mode: 'geant4'`) through any of the four resolution
+mechanisms: a `paths` mapping in `workflow_parameters`, the relevant
+environment variable (`ACE3P_PATH`, `GEANT4_APP_PATH` /
+`GEANT4_APP_EXE`), a built-in site default (Perlmutter / S3DF), or
+autodetection on `PATH`/`$HOME`. The workflow still runs end-to-end in
+Python but skips the external solver call and writes a `DRY_RUN.txt`
+marker in each working directory. To run a real workflow, set one of
+those paths — see [](installation.md#executable-paths) for the full
+precedence chain.
+
+### `lume-ace3p` is using the wrong ACE3P/Cubit/MPI binary — how do I override it?
+
+Add a `paths` mapping under `workflow_parameters`. YAML overrides take
+precedence over environment variables, site defaults, and autodetection:
+
+```yaml
+workflow_parameters :
+  'paths' :
+    'ace3p' : '/my/custom/ace3p/bin/'
+    'cubit' : '/my/custom/cubit/'
+    'mpi'   : 'srun'
+```
+
+This is the recommended way to pin a specific build for a given
+workflow file without changing your shell environment.
+
 ### Why does `lume-ace3p` fail to find the mesh file generated from Cubit?
 
 Check that the `.gen` filename provided in the Cubit journal `export`

--- a/docs/yaml_reference.md
+++ b/docs/yaml_reference.md
@@ -14,6 +14,8 @@ directory management, and other settings.
 
 | Keyword             | Type           | Default        | Description |
 |---------------------|----------------|----------------|-------------|
+| `mode`              | `str`          | *(required)*   | Workflow mode. One of `'parameter_sweep'`, `'scalar_optimize'`, `'gp_parameter_sweep'`, `'particle_weight'`, or `'geant4'`. See [](#workflow-modes). |
+| `module`            | `str`          | *(required)*   | ACE3P (or downstream) module driving the workflow. One of `'omega3p'`, `'s3p'`, `'track3p'`, or `'geant4'`. Valid combinations with `mode` are listed in [](#workflow-modes). |
 | `cubit_input`       | `str`          | `None`         | Path to the Cubit journal file (`.jou`) used for the workflow. |
 | `ace3p_input`       | `str`          | `None`         | Path to the ACE3P input file (e.g. `.omega3p`) used for the workflow. |
 | `ace3p_cores`       | `int`          | `1`            | Number of cores per task to use with ACE3P modules. |
@@ -24,6 +26,45 @@ directory management, and other settings.
 | `sweep_output_file` | `str`          | `None`         | Path for writing parameter-sweep output. |
 | `workdir`           | `str` / `Path` | `os.getcwd()`  | Path to the working directory in which `lume-ace3p` runs. |
 | `workdir_mode`      | `str`          | `'manual'`     | `'manual'` (single workflow folder) or `'auto'` (automatic folder generation). |
+| `skip_cubit`        | `bool`         | `False`        | If `True`, skip the Cubit mesh-generation step for every workflow run. Per-call overrides via `.run(skip_cubit=...)` take precedence. |
+| `skip_solver`       | `bool`         | `False`        | If `True`, skip the ACE3P solver step (Omega3P, S3P, …). |
+| `skip_acdtool`      | `bool`         | `False`        | If `True`, skip the acdtool postprocessing step (Omega3P workflows only). |
+| `skip_meshconvert`  | `bool`         | `False`        | If `True`, skip the Cubit-internal mesh-conversion step. |
+| `dry_run`           | `bool`         | `False`        | If `True`, run the full Python pipeline but skip Cubit/solver/acdtool calls (writes a `DRY_RUN.txt` marker). Auto-enabled when the relevant tool path cannot be resolved — see [](installation.md#dry-run-mode). |
+| `paths`             | `dict`         | `None`         | Mapping of executable-path overrides. Recognized keys: `ace3p`, `cubit`, `mpi`, `geant4_app_path`, `geant4_app_exe`. Each value takes highest precedence in path resolution — see [](installation.md#executable-paths). |
+
+(workflow-modes)=
+### Workflow modes
+
+The `mode` and `module` keys together select which workflow the
+`run_lume_ace3p` entry point dispatches to. Only the combinations below
+are recognized; other combinations are silently ignored.
+
+| `mode`                | `module`   | Required sections (besides `workflow_parameters`) | Behavior |
+|-----------------------|------------|---------------------------------------------------|----------|
+| `parameter_sweep`     | `omega3p`  | `cubit_input_parameters` and/or `ace3p_input_parameters`, `output_parameters` | Tensor-product sweep over Cubit + ACE3P inputs; acdtool postprocessing extracts `output_parameters`. |
+| `parameter_sweep`     | `s3p`      | `input_parameters` and/or `ace3p_input_parameters` | Tensor-product sweep; S-parameter output written to `sweep_output_file`. |
+| `scalar_optimize`     | `s3p`      | `vocs_parameters`, `xopt_parameters`              | Drives Xopt with `S3PWorkflow` as the evaluator. |
+| `gp_parameter_sweep`  | `s3p`      | `sweep_parameters`, `vocs_parameters`, `xopt_parameters` | Bayesian-exploration low-fidelity sweep — fits a Gaussian Process to S3P observables, then samples it on a tensor grid defined by `sweep_parameters`. See [examples/lf_param_sweep.yaml](https://github.com/slaclab/lume-ace3p/blob/main/examples/lf_param_sweep.yaml). |
+| `particle_weight`     | `track3p`  | `particle_parameters`                             | Standalone post-processing step (no ACE3P invocation). Reads a Track3P particle dump, filters/bins particles, computes per-particle field-emission weights, and writes a weighted-particle file. See [](#particle_parameters). |
+| `geant4`              | `geant4`   | `geant4_input_parameters` (optional), `output_parameters` (optional), `particle_parameters` (optional) | Drives `Geant4Workflow`. Optionally chains a `Particles` pre-step to generate the particle source from Track3P output. |
+
+### Geant4-workflow keys
+
+Used only when `module: 'geant4'` is selected (the workflow class is
+{py:class}`~lume_ace3p.workflow.Geant4Workflow`).
+
+| Keyword                   | Type   | Default                | Description |
+|---------------------------|--------|------------------------|-------------|
+| `geant4_input`            | `str`  | `None`                 | Path to the Geant4 macro file (`.mac`) used as the simulation input. |
+| `geant4_threads`          | `int`  | `1`                    | Number of threads passed to `/run/numberOfThreads` in the Geant4 macro. |
+| `geant4_opts`             | `str`  | `''`                   | Additional `mpirun`/`srun` arguments when launching the Geant4 application. |
+| `geant4_particle_cmd`     | `str`  | `'/lume/particleFile'` | Macro command used to inject the particle-source file path into the Geant4 macro. |
+| `geant4_geometry_files`   | `list` | `[]`                   | List of geometry/auxiliary files copied into the working directory before the Geant4 run. |
+| `geant4_particle_file`    | `str`  | `None`                 | Path to a pre-existing particle-source file. Ignored when `particle_parameters` is provided (in which case the file is generated from Track3P output). |
+| `geant4_scoring_output`   | `str`  | `None`                 | Filename (relative to the working directory) of the Geant4 scoring output read by `evaluate()`. |
+| `particle_input`          | `str`  | `None`                 | Path to the Track3P particle-data file consumed by `Particles` when generating a Geant4 source. |
+| `particle_output`         | `str`  | `None`                 | Output filename for the generated Geant4 source produced by `Particles`. |
 
 ## `input_parameters` / `cubit_input_parameters`
 
@@ -76,11 +117,100 @@ Currently supported values:
 
 More sections and entries will be added in future updates.
 
+## `ace3p_input_parameters`
+
+A nested mapping organized by ACE3P input-file hierarchy, used to override
+or sweep over values inside the `.omega3p` / `.s3p` / `.t3p` / `.track3p`
+input files (or to supply them inline when no separate ACE3P input file is
+provided). The same `min`/`max`/`num` and list conventions as
+`input_parameters` apply to leaf values; non-list scalars are written
+through unchanged.
+
+Two scalar attributes have special meaning when present in a sub-mapping:
+
+- `Attribute` — disambiguates blocks that share a name; rendered as
+  `BlockName|<value>|` in the patched ACE3P input.
+- `ReferenceNumber` — likewise, rendered as `BlockName?<value>?`.
+
+See the S3P-without-separate-file example in [](parameter_sweep.md) for a
+complete usage pattern.
+
+(sweep_parameters)=
+## `sweep_parameters`
+
+Used only with `mode: 'gp_parameter_sweep'`. Defines the tensor-product
+grid on which the trained Gaussian Process is sampled after the Xopt
+exploration phase. Same shape as `input_parameters`: each key is a
+variable name, each value is a `min`/`max`/`num` mapping (linearly
+spaced).
+
+(geant4_input_parameters)=
+## `geant4_input_parameters`
+
+Used only with `mode: 'geant4'`. Supplies overrides for Geant4 macro
+commands. Each key is a Geant4 macro command (typically beginning with
+`/`, e.g. `/run/numberOfThreads`, `/gun/energy`); each value is either a
+scalar to write through unchanged or a `min`/`max`/`num` mapping for a
+parameter sweep. Non-macro keys (those not starting with `/`) are
+filtered out before the macro is patched.
+
+(particle_parameters)=
+## `particle_parameters`
+
+Used with `mode: 'particle_weight'` (Track3P post-processing) and
+optionally with `mode: 'geant4'` (to generate the Geant4 particle source
+from a Track3P dump). Configures the `Particles` helper.
+
+| Keyword          | Type               | Default               | Description |
+|------------------|--------------------|-----------------------|-------------|
+| `impact_order`   | `int` or `list`    | *(required)*          | Track3P `ImpactOrder` value(s) to retain. Single int or list of ints. |
+| `impact_face_id` | `int` or `list`    | *(required)*          | Track3P `ImpactFaceID` value(s) to retain. |
+| `work_function`  | `float`            | *(required)*          | Surface work function (eV) used in the Fowler-Nordheim weighting. |
+| `dt`             | `float`            | *(required)*          | Time step (s) used to convert current density to particles per emission event. |
+| `beta`           | `list[float]`      | *(required)*          | Field-enhancement factor per axial bin. Length must equal `num_bins`. |
+| `num_bins`       | `int`              | `len(beta)`           | Number of axial (`Initial_z`) bins applied to the filtered particles. |
+| `bin_edges`      | `list[float]`      | `None` (auto-spaced)  | Explicit bin edges. If supplied, must have length `num_bins + 1`; otherwise edges are linearly spaced between the min and max `Initial_z` of the filtered particles. |
+
+The output file (path set by `workflow_parameters.particle_output`, or
+`<input>_modified.txt` if unset) contains the filtered Track3P columns
+plus a `Bin` column and a `ParticleWeight` column.
+
+## `xopt_parameters`
+
+Controls the Xopt optimization driver invoked by `run_xopt`. Most keys are
+optional; the required key is `generator`. At least one termination
+criterion (`num_step`, `cost_budget`, `alotted_time`, or — for `run_lf_sweep`
+— `max_steps`) must also be supplied.
+
+| Keyword                 | Type    | Default         | Description |
+|-------------------------|---------|-----------------|-------------|
+| `generator`             | `str`   | *(required)*    | Xopt generator name. Supported: `'NelderMeadGenerator'`, `'ExpectedImprovementGenerator'`, `'UpperConfidenceBoundGenerator'`, `'MultiFidelityGenerator'`, `'ExpectedHypervolumeImprovementGenerator'`. |
+| `generator_options`     | `dict`  | `{}`            | Keyword arguments forwarded verbatim to the chosen generator's constructor. Required for `ExpectedHypervolumeImprovementGenerator` (must include `reference_point`); also used for UCB tuning. |
+| `num_random`            | `int`   | `0` (or `2` for multi-fidelity, `5` for `run_lf_sweep`) | Number of initial random evaluations used to seed the model. |
+| `num_step`              | `int`   | `None`          | Number of optimization steps after the random-seeding phase. |
+| `max_iterations`        | `int`   | `None`          | Total iteration cap (random + step). When set together with `tolerance` (in `vocs_parameters.objectives`), optimization stops as soon as all objectives meet the tolerance or the cap is hit. |
+| `max_steps`             | `int`   | `None`          | Used by `run_lf_sweep` only; analogue of `num_step` for the low-fidelity sweep mode. |
+| `improvement_threshold` | `float` | `0.01`          | Used by `run_lf_sweep`. Relative-improvement threshold for the early-stopping check. |
+| `patience`              | `int`   | `5`             | Used by `run_lf_sweep`. Number of consecutive iterations without improvement before stopping. |
+| `cost_budget`           | `float` | `None`          | Multi-fidelity termination criterion; total cost (in `xopt_runtime` units) at which optimization stops. |
+| `alotted_time`          | `str`   | `None`          | Alternative multi-fidelity criterion in `'HH:MM:SS'` format; converted to a cost budget in seconds. |
+| `cost_function`         | `str`   | `'exponential'` | Multi-fidelity cost-function model. One of `'exponential'` or `'gaussian_process'`. |
+| `fidelity_variable`     | `str`   | `'s'`           | Multi-fidelity only. Name of the input variable interpreted as the fidelity coordinate; the column is renamed from `'s'` in the input dict. |
+| `save_model`            | `bool`  | `False`         | If `True`, save the trained generator's GP model state to `Binary_gp_model.pt` and a human-readable summary to `gp_parameters.txt`. |
+
 ## Workflow classes
 
-The {py:class}`~lume_ace3p.workflow.Omega3PWorkflow` class can be
-instantiated using only a workflow dict. An `Omega3PWorkflow` object can
-run as-is, but no workflow input files will be adjusted in that case.
+`lume-ace3p` exposes one workflow class per supported module:
+
+- {py:class}`~lume_ace3p.workflow.Omega3PWorkflow` — Omega3P + Cubit + acdtool.
+- {py:class}`~lume_ace3p.workflow.S3PWorkflow` — S3P + Cubit (no acdtool).
+- {py:class}`~lume_ace3p.workflow.Geant4Workflow` — Geant4 dose calculation,
+  optionally driven by Track3P particle output via the `Particles` helper.
+
+All three subclass `ACE3PWorkflow` and share the core constructor
+signature shown below. Each can be instantiated using only a workflow
+dict — additional input/output dicts are optional, but no workflow input
+files will be adjusted without them.
 
 ### Constructor
 


### PR DESCRIPTION
Documents previously-undocumented features added in recent commits:
- Geant4 module and Geant4Workflow (workflow_parameters keys, mode/module combinations, geant4_input_parameters section)
- Particles helper and particle_parameters section (particle_weight mode)
- gp_parameter_sweep mode and sweep_parameters section
- Executable-path resolution chain (YAML > env > site default > autodetect) and the new auto-enabled dry-run triggers
- Required mode/module keys, skip_* flags, paths override, and the full xopt_parameters key list

Generated with AI

Co-Authored-By: SLAC AI