### PR TITLE
Reframe workflow-setup docs as composable module list, fix sweep details

### DIFF
--- a/docs/parameter_sweep.md
+++ b/docs/parameter_sweep.md
@@ -104,8 +104,11 @@ if not swept.
 
 In this example `cav_radius` and `ellipticity` are length-4 vectors, and
 `Sigma` has two values, giving 4 × 4 × 2 = 32 workflow evaluations. Because
-`workdir_mode` is `auto`, each evaluation creates a folder named
-`lume-ace3p_demo_workdir_X_Y_Z` for a total of 32 folders.
+`workdir_mode` is `auto`, each evaluation creates a folder named from the
+`workdir` base plus the swept scalar values (e.g.
+`lume-ace3p_omega3p_workdir_90.0_0.5_58000000.0`) for a total of 32 folders. The
+full `cubit → omega3p → acdtool` chain — including the in-`cubit` meshconvert —
+re-runs in each folder.
 
 Then, output parameters:
 
@@ -125,10 +128,12 @@ section id (`'RoverQ'`), mode/surface id string (`'0'`), and entry name
 from `rfpost.out`. The `output_file` is a tab-delimited table with one column
 per input or output, one row per workflow evaluation.
 
-In this example the first row contains 8 text entries (`cav_radius`,
-`ellipticity`, `R/Q`, `mode_freq`, `E_max`, `loc_x`, `loc_y`, `loc_z`); each
-subsequent row holds the input values and the corresponding 6 outputs. See
-[](yaml_reference.md) for the full list of supported output sections.
+In this example the table has 9 columns — one per swept axis (`cav_radius`,
+`ellipticity`, and the swept ACE3P leaf, whose column is labeled by its path
+`ace3p:ModelInfo.SurfaceMaterial.Sigma`) followed by the 6 declared outputs
+(`R/Q`, `Mode_freq`, `E_max`, `loc_x`, `loc_y`, `loc_z`) — with one row per
+workflow evaluation. See [](yaml_reference.md) for the full list of supported
+output sections.
 
 If no output dict is specified, the parameter sweep still runs but
 `rfpost.out` data will not be parsed or tabulated (useful when only the
@@ -240,12 +245,11 @@ a necessary ACE3P input parameter is missing.
 
 ## Viewing S3P parameter sweep output
 
-A simple plotting tool is included with `lume-ace3p` which reads
-`sweep_output_file` from an S3P workflow and plots the results in an
-interactive plot. To use it, run `s3p_sweep_plot.py` and load the appropriate
-S3P `sweep_output_file` from the file prompt. Try `s3p_demo_sweep_output.txt`
-in the `plotting` folder for an interactive demo. See [](plotting.md) for
-details.
+A simple plotting tool is included with `lume-ace3p` which reads the S3P sweep
+result table (the `mode.output_file`) and plots the results in an interactive
+plot. To use it, run `s3p_sweep_plot.py` and load the appropriate S3P
+`output_file` from the file prompt. Try `s3p_demo_sweep_output.txt` in the
+`plotting` folder for an interactive demo. See [](plotting.md) for details.
 
 ## Gaussian-process (low-fidelity) parameter sweep
 

--- a/docs/workflow_inputs.md
+++ b/docs/workflow_inputs.md
@@ -1,10 +1,15 @@
 # Setting up workflow input files
 
-Internally, `lume-ace3p` evaluates ACE3P workflows (e.g. Cubit → Omega3P →
-acdtool task chains), each of which requires its own input files. Typical
-input files used in ACE3P workflows need only minimal adjustment for use with
-`lume-ace3p`. The main consideration is making sure variable and file names
-are consistent throughout each input file.
+A `lume-ace3p` run is a user-composed **`workflow:`** — an ordered list of
+modules (`cubit`, `omega3p`/`s3p`, `acdtool`, `track3p_source`, `particles`,
+`geant4`, …) that are validated into a runnable DAG by their artifact
+dependencies. The chain is *not* a fixed pipeline: you list only the modules you
+want (an Omega3P sweep is `cubit → omega3p → acdtool`; an S3P sweep is
+`cubit → s3p`), and each module carries its own input-file references. This page
+covers the external input files those modules consume; see [](yaml_reference.md)
+for the module list itself. Typical ACE3P input files need only minimal
+adjustment for use with `lume-ace3p` — the main consideration is making sure
+variable and file names are consistent throughout each input file.
 
 ## Cubit journal files
 
@@ -40,9 +45,14 @@ option, e.g.:
 export Genesis "my_mesh_file.gen" block all overwrite
 ```
 
-This exports the generated mesh into a `.gen` file, and `lume-ace3p`
-automatically calls acdtool to convert it to a `.ncdf` file with the same name
-(`my_mesh_file.ncdf` here).
+This exports the generated mesh into a `.gen` file. The mesh conversion is a
+sub-step *inside* the `cubit` module — after meshing, the module calls acdtool
+to convert the `.gen` file to a `.ncdf` file of the same name (`my_mesh_file.ncdf`
+here). It is not a separate workflow entry; toggle it with `meshconvert: false`
+on the `cubit` module entry when the journal already exports a `.ncdf` mesh (or
+you otherwise want to skip conversion). To skip Cubit meshing entirely, drop the
+`cubit` module and provide the mesh with a `mesh` source module instead — see
+[](yaml_reference.md).
 
 For more information on Cubit journal files, see the official
 [Cubit documentation](https://cubit.sandia.gov/documentation/).


### PR DESCRIPTION
The parameter-sweep YAML examples were already migrated, but the framing still read as a fixed Cubit->solver->acdtool pipeline and never explained that meshconvert is a sub-step inside the cubit module.

- workflow_inputs.md: open with the composable workflow: module list (not a fixed task chain); describe .gen->.ncdf conversion as the in-cubit meshconvert sub-step toggled by meshconvert:, and note the mesh source module for skipping Cubit entirely.
- parameter_sweep.md: correct the auto workdir folder-name example, note the full chain re-runs per grid point, fix the Omega3P result-table column count (9 cols incl. the swept ace3p:...Sigma leaf, not 8), and update the stale sweep_output_file plotting reference to mode.output_file.

Generated with AI

Co-Authored-By: SLAC AI